### PR TITLE
Update MASTER FUNCTIONS LIBRARY.vbs

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -2460,8 +2460,8 @@ FUNCTION run_from_GitHub(url)
 END FUNCTION
 
 function script_end_procedure(closing_message)
-	If closing_message <> "" then MsgBox closing_message
 	stop_time = timer
+	If closing_message <> "" then MsgBox closing_message
 	script_run_time = stop_time - start_time
 	If is_county_collecting_stats  = True then
 		'Getting user name


### PR DESCRIPTION
Modifying the order of script_end_procedure to have the timer stop BEFORE the closing message. This is a more accurate reflection of script run time as the user leaving the closing message up was keeping the timer running.