### PR TITLE
Fixing BUSI issues

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -183,9 +183,9 @@ Function add_BUSI_to_variable(variable_name_for_BUSI) 'x represents the name of 
 		EMReadScreen BUSI_footer_month, 5, 20, 55
 		BUSI_footer_month = replace(BUSI_footer_month, " ", "/01/")
 		If datediff("d", date, BUSI_footer_month) > 0 then
-			pull_future_HC = False
+			pull_future_HC = TRUE
 		Else
-			pull_future_HC = True
+			pull_future_HC = FALSE
 		End if
 	
 		'Converting BUSI type code to a human-readable string
@@ -292,13 +292,8 @@ Function add_BUSI_to_variable(variable_name_for_BUSI) 'x represents the name of 
 		If BUSI_SNAP_retro_amt <> "0.00" then variable_name_for_BUSI = variable_name_for_BUSI & "- SNAP retro: $" & BUSI_SNAP_retro_amt & " budgeted, " & BUSI_SNAP_ver & "; "
 		If BUSI_SNAP_pro_amt <> "0.00" then variable_name_for_BUSI = variable_name_for_BUSI & "- SNAP pro: $" & BUSI_SNAP_pro_amt & " budgeted, " & BUSI_SNAP_ver & "; "
 		'Leaving out HC income estimator if footer month is not Current month + 1
-		current_month_for_hc_est = dateadd("m", "1", date)
-		current_month_for_hc_est = datepart("m", current_month_for_hc_est)
-		IF len(current_month_for_hc_est) = 1 THEN current_month_for_hc_est = "0" & current_month_for_hc_est
-		IF footer_month = current_month_for_hc_est THEN
-			If BUSI_HCA_amt <> "0.00" then variable_name_for_BUSI = variable_name_for_BUSI & "- HC Method A: $" & BUSI_HCA_amt & " budgeted, " & BUSI_HCA_ver & "; "
-			If BUSI_HCB_amt <> "0.00" then variable_name_for_BUSI = variable_name_for_BUSI & "- HC Method B: $" & BUSI_HCB_amt & " budgeted, " & BUSI_HCB_ver & "; "
-		END IF
+		If BUSI_HCA_amt <> "0.00" then variable_name_for_BUSI = variable_name_for_BUSI & "- HC Method A: $" & BUSI_HCA_amt & " budgeted, " & BUSI_HCA_ver & "; "
+		If BUSI_HCB_amt <> "0.00" then variable_name_for_BUSI = variable_name_for_BUSI & "- HC Method B: $" & BUSI_HCB_amt & " budgeted, " & BUSI_HCB_ver & "; "
 		'Checks to see if pre 01/15 or post 02/15 then decides what to put in case note based on what was found/needed on the self employment method.
 		If IsDate(BUSI_income_end_date) = false then
 			IF BUSI_method <> "__" or BUSI_method = "" THEN 


### PR DESCRIPTION

Swapped logic as it was currently stating 31>0 = false
removed conditional logic for writing the health care numbers if the footer_month isn't CM+1. There was a 2 checks to determine if to grab prosp or grab income estimator.

#127