### PR TITLE
Resolves #146

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1599,6 +1599,18 @@ Function check_for_MAXIS(end_script)
 	Loop until MAXIS_check = "MAXIS" or MAXIS_check = "AXIS "
 End function
 
+Function check_for_password(are_we_passworded_out)
+	Transmit 'transmitting to see if the password screen appears
+	Emreadscreen password_check, 8, 2, 33 'checking for the word password which will indicate you are passworded out
+	If password_check = "PASSWORD" then 'If the word password is found then it will tell the worker and set the parameter to be true, otherwise it will be set to false.
+		Msgbox "Are you passworded out? Press OK and the dialog will reappear. Once it does, you can enter your password."
+		are_we_passworded_out = true
+	Else 
+		are_we_passworded_out = false
+	End If 
+End Function
+
+
 Function check_for_PRISM(end_script)
 	EMReadScreen PRISM_check, 5, 1, 36
 	if end_script = True then


### PR DESCRIPTION
This function takes a parameter and determines if the user is passworded out. This can be used in conjunction with an extra do...loop around a dialog to make sure that the end user has an opportunity to get back to their dialog. 
Stearns county runs a newer version of Bluezone that causes issues when a script is running while Bluezone passwords out. This function is a workaround to allow the worker to enter the password without losing the dialog information.