### PR TITLE
Resolved issue #196, call autofill from MAXIS for WREG not counting ABAWD months

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1487,8 +1487,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
       EMWriteScreen "01", 20, 79
       transmit
     EMReadScreen wreg_total, 1, 2, 78
-    EMReadScreen snap_case_yn, 1, 6, 50
-    IF wreg_total <> "0" and snap_case_yn = "Y" THEN
+    IF wreg_total <> "0" THEN
 	EmWriteScreen "x", 13, 57
 	transmit
 	 bene_mo_col = (15 + (4*cint(footer_month)))


### PR DESCRIPTION
BLIP: Removed SNAP program panel check from function as this was preventing the script from autofilling the ABAWD months.