### PR TITLE
Resolves #205: stopscript disabled at times 

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -2542,7 +2542,7 @@ function script_end_procedure(closing_message)
         End if
 
 	End if
-	stopscript
+	If disable_StopScript = FALSE or disable_StopScript = "" then stopscript
 end function
 
 function script_end_procedure_wsh(closing_message) 'For use when running a script outside of the BlueZone Script Host


### PR DESCRIPTION
Blip: The `script_end_procedure` has a new feature - if `disable_StopScript` is set to `true`, the function will keep running and not stop the script, allowing chain-loading with ease.