### PR TITLE
RESOLVES #225 reworking footer_month_finder to work on memo

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -2429,6 +2429,7 @@ FUNCTION MAXIS_dialog_navigation
     If ButtonPressed = WKEX_button then call navigate_to_MAXIS_screen("stat", "WKEX")
 END FUNCTION
 
+
 FUNCTION MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)'Grabbing the footer month/year
 	'Does this to check to see if we're on SELF screen
 	EMReadScreen SELF_check, 4, 2, 50
@@ -2436,9 +2437,15 @@ FUNCTION MAXIS_footer_finder(MAXIS_footer_month, MAXIS_footer_year)'Grabbing the
 		EMReadScreen MAXIS_footer_month, 2, 20, 43
 		EMReadScreen MAXIS_footer_year, 2, 20, 46
 	ELSE
-		Call find_variable("Month: ", MAXIS_footer, 5)
-		MAXIS_footer_month = left(MAXIS_footer, 2)
-		MAXIS_footer_year = right(MAXIS_footer, 2)
+		EMReadScreen MEMO_check, 4, 2, 47
+		IF MEMO_check = "MEMO" Then	
+			EMReadScreen MAXIS_footer_month, 2, 19, 54
+			EMReadScreen MAXIS_footer_year, 2, 49, 57
+		ELSE
+			Call find_variable("Month: ", MAXIS_footer, 5)
+			MAXIS_footer_month = left(MAXIS_footer, 2)
+			MAXIS_footer_year = right(MAXIS_footer, 2)
+		END IF
 	End if
 END FUNCTION
 


### PR DESCRIPTION
BLIP: function now has ability to correctly pull footer month/year information off of spec/memo