### PR TITLE
Resolved #257: added pass-through for sending data to Access

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1750,7 +1750,7 @@ End function
 FUNCTION cancel_confirmation
 	If ButtonPressed = 0 then
 		cancel_confirm = MsgBox("Are you sure you want to cancel the script? Press YES to cancel. Press NO to return to the script.", vbYesNo)
-		If cancel_confirm = vbYes then script_end_procedure("CANCEL BUTTON SELECTED")     
+		If cancel_confirm = vbYes then script_end_procedure("~PT: user pressed cancel")     
         'script_end_procedure text added for statistical purposes. If script was canceled prior to completion, the statistics will reflect this.
 	End if
 END FUNCTION
@@ -3074,8 +3074,7 @@ END FUNCTION
 
 function script_end_procedure(closing_message)
 	stop_time = timer
-	If closing_message <> "" AND closing_message <> "CANCEL BUTTON SELECTED" then MsgBox closing_message
-    'Bypasses the closing message of "CANCEL BUTTON SELECTED" in the cancel_confirmation function if being used in scripts where chain-loading is occurring
+	If closing_message <> "" AND left(closing_message, 3) <> "~PT" then MsgBox closing_message '"~PT" forces the message to "pass through", i.e. not create a pop-up, but to continue without further diversion to the database, where it will write a record with the message
 	script_run_time = stop_time - start_time
 	If is_county_collecting_stats  = True then
 		'Getting user name


### PR DESCRIPTION
Blip: a "pass through" function was installed for scriptwriters. To
create a message on the Access database without creating a corresponding
pop-up, simply use `script_end_procedure("~PT: [message goes here]")`.
The contents of the message will be passed through to the database
without showing up as a pop-up.

@courtrightd, @C-Love, @IlseFerris, @gays, @CDPotter, and
@RobertFewins-Kalb may find this interesting, as I know your agencies
use the database (or are in the process of doing so).