### PR TITLE
Resolved #262 Autofill from MAXIS for Wreg panel/ABAWD stauts update

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1679,7 +1679,6 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 			'declaring & splitting the second set of abawd months array
 			If left(second_set_info_list, 1) = "," then second_set_info_list = right(second_set_info_list, len(second_set_info_list) - 1)
 			second_months_array = Split(second_set_info_list,",")
-			If second_set_info_list = "" then second_set_info_list = "none"
 
 			bene_mo_col = bene_mo_col - 4
     		IF bene_mo_col = 15 THEN
@@ -1725,7 +1724,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 	If read_abawd_status = "07" THEN  abawd_status = "ABAWD = work exp participant."
 	If read_abawd_status = "08" THEN  abawd_status = "ABAWD = othr E & T service."
 	If read_abawd_status = "09" THEN  abawd_status = "ABAWD = reside in waiver area."
-	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used: " & second_set_info_list & "."
+	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used:" & second_set_info_list & "."
 	If read_abawd_status = "11" THEN  abawd_status = "ABAWD = Using 2nd set of ABAWD months. List of 2nd set used:" & second_set_info_list & "."
 	If read_abawd_status = "12" THEN  abawd_status = "ABAWD = RCA or GA recip."
 	If read_abawd_status = "13" THEN  abawd_status = "ABAWD = ABAWD extension."

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1679,7 +1679,6 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 			'declaring & splitting the second set of abawd months array
 			If left(second_set_info_list, 1) = "," then second_set_info_list = right(second_set_info_list, len(second_set_info_list) - 1)
 			second_months_array = Split(second_set_info_list,",")
-			If second_set_info_list = "" then second_set_info_list = "none"
 
 			bene_mo_col = bene_mo_col - 4
     		IF bene_mo_col = 15 THEN
@@ -1725,7 +1724,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 	If read_abawd_status = "07" THEN  abawd_status = "ABAWD = work exp participant."
 	If read_abawd_status = "08" THEN  abawd_status = "ABAWD = othr E & T service."
 	If read_abawd_status = "09" THEN  abawd_status = "ABAWD = reside in waiver area."
-	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo. List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used: " & second_set_info_list & "."
+	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used:" & second_set_info_list & "."
 	If read_abawd_status = "11" THEN  abawd_status = "ABAWD = Using 2nd set of ABAWD months. List of 2nd set used:" & second_set_info_list & "."
 	If read_abawd_status = "12" THEN  abawd_status = "ABAWD = RCA or GA recip."
 	If read_abawd_status = "13" THEN  abawd_status = "ABAWD = ABAWD extension."

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1679,7 +1679,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 			'declaring & splitting the second set of abawd months array
 			If left(second_set_info_list, 1) = "," then second_set_info_list = right(second_set_info_list, len(second_set_info_list) - 1)
 			second_months_array = Split(second_set_info_list,",")
-
+		
 			bene_mo_col = bene_mo_col - 4
     		IF bene_mo_col = 15 THEN
         		bene_yr_row = bene_yr_row - 1
@@ -1724,8 +1724,14 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 	If read_abawd_status = "07" THEN  abawd_status = "ABAWD = work exp participant."
 	If read_abawd_status = "08" THEN  abawd_status = "ABAWD = othr E & T service."
 	If read_abawd_status = "09" THEN  abawd_status = "ABAWD = reside in waiver area."
-	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used:" & second_set_info_list & "."
-	If read_abawd_status = "11" THEN  abawd_status = "ABAWD = Using 2nd set of ABAWD months. List of 2nd set used:" & second_set_info_list & "."
+	IF read_abawd_status = "10" AND abawd_counted_months = "0" THEN 
+		abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo."
+	Elseif read_abawd_status = "10" AND second_abawd_period = "0" THEN 
+		abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo. Counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used: " & second_abawd_period & "."
+	Elseif read_abawd_status = "10" AND second_abawd_period <> "0" THEN
+		abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo. Counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used: " & second_abawd_period & ". Counted second set months: " & second_set_info_list & "."
+	END IF 
+	If read_abawd_status = "11" THEN  abawd_status = "ABAWD = Using second set of ABAWD months. Counted second set months: " & second_set_info_list & "."
 	If read_abawd_status = "12" THEN  abawd_status = "ABAWD = RCA or GA recip."
 	If read_abawd_status = "13" THEN  abawd_status = "ABAWD = ABAWD extension."
 	If read_abawd_status = "__" THEN  abawd_status = "ABAWD = blank"

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1662,6 +1662,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 			'declaring & splitting the second set of abawd months array
 			If left(second_set_info_list, 1) = "," then second_set_info_list = right(second_set_info_list, len(second_set_info_list) - 1)
 			second_months_array = Split(second_set_info_list,",")
+			If second_set_info_list = "" then second_set_info_list = "none"
 
 			bene_mo_col = bene_mo_col - 4
     		IF bene_mo_col = 15 THEN
@@ -1707,7 +1708,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 	If read_abawd_status = "07" THEN  abawd_status = "ABAWD = work exp participant."
 	If read_abawd_status = "08" THEN  abawd_status = "ABAWD = othr E & T service."
 	If read_abawd_status = "09" THEN  abawd_status = "ABAWD = reside in waiver area."
-	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used:" & second_set_info_list & "."
+	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used: " & second_set_info_list & "."
 	If read_abawd_status = "11" THEN  abawd_status = "ABAWD = Using 2nd set of ABAWD months. List of 2nd set used:" & second_set_info_list & "."
 	If read_abawd_status = "12" THEN  abawd_status = "ABAWD = RCA or GA recip."
 	If read_abawd_status = "13" THEN  abawd_status = "ABAWD = ABAWD extension."

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -1679,6 +1679,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 			'declaring & splitting the second set of abawd months array
 			If left(second_set_info_list, 1) = "," then second_set_info_list = right(second_set_info_list, len(second_set_info_list) - 1)
 			second_months_array = Split(second_set_info_list,",")
+			If second_set_info_list = "" then second_set_info_list = "none"
 
 			bene_mo_col = bene_mo_col - 4
     		IF bene_mo_col = 15 THEN
@@ -1724,7 +1725,7 @@ Function autofill_editbox_from_MAXIS(HH_member_array, panel_read_from, variable_
 	If read_abawd_status = "07" THEN  abawd_status = "ABAWD = work exp participant."
 	If read_abawd_status = "08" THEN  abawd_status = "ABAWD = othr E & T service."
 	If read_abawd_status = "09" THEN  abawd_status = "ABAWD = reside in waiver area."
-	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo." & " List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used:" & second_set_info_list & "."
+	If read_abawd_status = "10" THEN  abawd_status = "ABAWD = ABAWD & has used " & abawd_counted_months & " mo. List of counted ABAWD months:" & abawd_info_list & ". Second set of ABAWD months used: " & second_set_info_list & "."
 	If read_abawd_status = "11" THEN  abawd_status = "ABAWD = Using 2nd set of ABAWD months. List of 2nd set used:" & second_set_info_list & "."
 	If read_abawd_status = "12" THEN  abawd_status = "ABAWD = RCA or GA recip."
 	If read_abawd_status = "13" THEN  abawd_status = "ABAWD = ABAWD extension."


### PR DESCRIPTION
Blip: If client hasn't used 2nd set, the 2nd set number will register 0, and the verbiage about the second set months used will not be added to the edit box.. Also if client is a 30/10 and has not used any ABAWD months, the verbiage about the list of used months will not be added to the edit box.