### PR TITLE
#323: updated changelog_display to ensure the changelog text file is closed

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -2117,7 +2117,8 @@ function changelog_display()
 
 		end if
 
-		Set objTextStream = Nothing
+		'Close the file
+		objTextStream.Close
 	End with
 
 end function


### PR DESCRIPTION
This now uses `objTextStream.Close` instead of `set objTextStream =
nothing`. @C-Love will test.