### PR TITLE
Resolved #361, script_end_procedure to include case number input

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -3965,7 +3965,12 @@ function script_end_procedure(closing_message)
         else
             SCRIPT_success = 0
         end if
-
+		
+		'Determines if the value of the MAXIS case number - BULK and UTILITIES scripts will not have case number informaiton input into the database									
+		IF left(name_of_script, 4) = "BULK" or left(name_of_script, 4) = "UTIL" then 	
+			MAXIS_CASE_NUMBER = ""											
+		End if 
+		
 		'Creating objects for Access
 		Set objConnection = CreateObject("ADODB.Connection")
 		Set objRecordSet = CreateObject("ADODB.Recordset")
@@ -3979,17 +3984,22 @@ function script_end_procedure(closing_message)
 		ELSE
 			objConnection.Open "Provider = Microsoft.ACE.OLEDB.12.0; Data Source = " & "" & stats_database_path & ""
 		END IF
-
+		
         'Adds some data for users of the old database, but adds lots more data for users of the new.
         If STATS_enhanced_db = false or STATS_enhanced_db = "" then     'For users of the old db
     		'Opening usage_log and adding a record
     		objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX)" &  _
     		"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & script_run_time & ", '" & closing_message & "')", objConnection, adOpenStatic, adLockOptimistic
-        Else    'for users of the new db
+		'collecting case numbers counties
+		Elseif collect_case_number = true then 
+			objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS, CASE_NUMBER)" &  _
+			"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ", '" & MAXIS_CASE_NUMBER & "')", objConnection, adOpenStatic, adLockOptimistic
+		 'for users of the new db
+		Else   
             objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS)" &  _
             "VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ")", objConnection, adOpenStatic, adLockOptimistic
         End if
-
+		
 		'Closing the connection
 		objConnection.Close
 	End if

--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -3991,7 +3991,7 @@ function script_end_procedure(closing_message)
     		objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX)" &  _
     		"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & script_run_time & ", '" & closing_message & "')", objConnection, adOpenStatic, adLockOptimistic
 		'collecting case numbers counties
-		Elseif collect_case_number = true then 
+		Elseif collect_MAXIS_case_number = true then 
 			objRecordSet.Open "INSERT INTO usage_log (USERNAME, SDATE, STIME, SCRIPT_NAME, SRUNTIME, CLOSING_MSGBOX, STATS_COUNTER, STATS_MANUALTIME, STATS_DENOMINATION, WORKER_COUNTY_CODE, SCRIPT_SUCCESS, CASE_NUMBER)" &  _
 			"VALUES ('" & user_ID & "', '" & date & "', '" & time & "', '" & name_of_script & "', " & abs(script_run_time) & ", '" & closing_message & "', " & abs(STATS_counter) & ", " & abs(STATS_manualtime) & ", '" & STATS_denomination & "', '" & worker_county_code & "', " & SCRIPT_success & ", '" & MAXIS_CASE_NUMBER & "')", objConnection, adOpenStatic, adLockOptimistic
 		 'for users of the new db

--- a/stats/sql_table_schema_MAXIS_case_number.sql
+++ b/stats/sql_table_schema_MAXIS_case_number.sql
@@ -1,0 +1,21 @@
+CREATE TABLE [dbo].[usage_log](
+       [ID] [bigint] IDENTITY(1,1) NOT NULL,
+       [USERNAME] [varchar](255) NULL,
+       [SDATE] [date] NULL,
+       [STIME] [varchar](255) NULL,
+       [SCRIPT_NAME] [varchar](255) NULL,
+       [SRUNTIME] [decimal](18, 3) NULL,
+       [CLOSING_MSGBOX] [varchar](max) NULL,
+       [STATS_COUNTER] [int] NULL CONSTRAINT [DF_usage_log_STATS_COUNTER]  DEFAULT ((0)),
+       [STATS_MANUALTIME] [int] NULL CONSTRAINT [DF_usage_log_STATS_MANUALTIME]  DEFAULT ((0)),
+       [STATS_DENOMINATION] [varchar](255) NULL,
+       [WORKER_COUNTY_CODE] [varchar](255) NULL,
+       [SCRIPT_SUCCESS] [bit] NULL,
+       [CASE_NUMBER] [varchar](8) NULL, 
+CONSTRAINT [PK_usage_log] PRIMARY KEY CLUSTERED 
+(
+       [ID] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [Data]
+) ON [Data] TEXTIMAGE_ON [Data]
+
+GO


### PR DESCRIPTION
Users will need to update global variables to include `collect_MAXIS_case_number = true` to use. Added schema for MAXIS users. We can also talk about enhancing this for use on the PRISM side.