### PR TITLE
#397, #398 FuncLib updates for STAT/JOBS changes

### DIFF
--- a/MASTER FUNCTIONS LIBRARY.vbs
+++ b/MASTER FUNCTIONS LIBRARY.vbs
@@ -569,7 +569,7 @@ function add_JOBS_to_variable(variable_name_for_JOBS)
     HC_JOBS_amt = trim(HC_JOBS_amt)
     transmit
 
-  EMReadScreen JOBS_ver, 1, 6, 38
+  EMReadScreen JOBS_ver, 1, 6, 34
   EMReadScreen JOBS_income_end_date, 8, 9, 49
 	'This now cleans up the variables converting codes read from the panel into words for the final variable to be used in the output.
   If JOBS_income_end_date <> "__ __ __" then JOBS_income_end_date = replace(JOBS_income_end_date, " ", "/")
@@ -6207,13 +6207,10 @@ function write_panel_to_MAXIS_JOBS(jobs_number, jobs_inc_type, jobs_inc_verif, j
 	ELSE
 		PF9
 	END IF
-	IF ((MAXIS_footer_month * 1) >= 10 AND (MAXIS_footer_year * 1) >= "16") OR (MAXIS_footer_year = "17") THEN
-		EMWriteScreen jobs_inc_type, 5, 34
-		EMWriteScreen jobs_inc_verif, 6, 34
-	ELSE
-		EMWriteScreen jobs_inc_type, 5, 38
-		EMWriteScreen jobs_inc_verif, 6, 38
-	END IF
+	
+	EMWriteScreen jobs_inc_type, 5, 34
+	EMWriteScreen jobs_inc_verif, 6, 34
+	
 	EMWriteScreen jobs_employer_name, 7, 42
 	call create_MAXIS_friendly_date(jobs_inc_start, 0, 9, 35)
 	EMWriteScreen jobs_pay_freq, 18, 35


### PR DESCRIPTION
This is associated with MAXIS scripts issue #2999. Column for income type and jobs verification codes changed 10/16. Coding that was added at the time doesn't account for years that are not 2016 or 2017.